### PR TITLE
Update method validator signature

### DIFF
--- a/overview/valid-constraints/README.md
+++ b/overview/valid-constraints/README.md
@@ -121,12 +121,12 @@ myField = { max = 25 }
 
 ## method
 
-The `methodName` will be called on the target object and it will pass in the target, validationData, targetValue. It must return a boolean response: **true** = pass, **false** = fail.
+The `methodName` will be called on the target object and it will pass in validationData and targetValue. It must return a boolean response: **true** = pass, **false** = fail.
 
 ```javascript
 myField = { method = "methodName" }
 
-function methodName( target, value ){
+function methodName( validationData, targetValue ){
     return true;
 }
 ```


### PR DESCRIPTION
MethodValidator.cfc invokes the method with this signature:

`invoke( arguments.target, arguments.validationData, [ arguments.targetValue ] )`

The docs previously indicated `target, value` instead of `validationData, targetValue`