### PR TITLE
Add documentation for UDF/method validator errorMetadata + Nested Object Example

### DIFF
--- a/overview/valid-constraints/README.md
+++ b/overview/valid-constraints/README.md
@@ -91,7 +91,7 @@ propertyName = {
         // specific type constraint, one in the list.
         type  : (alpha,array,binary,boolean,component,creditcard,date,email,eurodate,float,GUID,integer,ipaddress,json,numeric,query,ssn,string,struct,telephone,url,usdate,UUID,xml,zipcode),
 
-        // UDF to use for validation, must return boolean accept the incoming value and target object, validate(value,target):boolean
+        // UDF to use for validation, must return boolean accept the incoming value and target object, validate(value,target,metadata):boolean
         udf = variables.UDF or this.UDF or a closure.
 
         // Check if a column is unique in the database
@@ -382,13 +382,16 @@ myField = { max = 25 }
 
 ## method
 
-The `methodName` will be called on the target object and it will pass in validationData and targetValue. It must return a boolean response: **true** = pass, **false** = fail.
+The `methodName` will be called on the target object and it will pass in validationData, targetValue, and metadata. It must return a boolean response: **true** = pass, **false** = fail.
+
+Any data you place in the `metadata` structure will be set in the validation result object for later retrieval.
 
 ```javascript
 myField = { method = "methodName" }
 
-function methodName( validationData, targetValue ){
-    return true;
+function methodName( validationData, targetValue, metadata ){
+    metadata[ "customMessage" ] = "I am a custom message set via metadata.";
+    return false;
 }
 ```
 
@@ -534,11 +537,17 @@ myField = { type : "xml" }
 
 ## udf
 
-The field value will be passed to the declared closure/lambda to use for validation, must return **boolean** accept the incoming value and target object, `validate(value,target):boolean`
+The field value, the target object, and an empty metadata structure will be passed to the declared closure/lambda to use for validation. The UDF must return **boolean**, `validate( value, target, metadata ):boolean`
+
+Any data you place in the `metadata` structure will be set in the validation result object for later retrieval.
 
 ```javascript
-myField = { udf = function( value, target ) { return true; } }
-myField = { udf = (value,target) => true }
+myField = { udf = function( value, target, metadata ) { return true; } }
+myField = { udf = (value ,target, metadata ) => true }
+myField = { udf = function( value, target, metadata ) { 
+    metadata[ "customMessage" ] = "This is a custom error message from within the udf";
+    return false; 
+}
 ```
 
 ## unique

--- a/overview/validating-constraints/validating-nested-objects.md
+++ b/overview/validating-constraints/validating-nested-objects.md
@@ -1,0 +1,37 @@
+# Validating Nested Objects
+
+We also have the ability to validate a nested object like a dependency or composed property and "bubble up" any validation error messages via the `errorMetadata` argument.
+
+```javascript
+// inject validationManager to handle nested validations
+property name="validationManager" inject="validationManager@cbvalidation";
+
+// root object constraints
+this.constraints = {
+    // validate a child object using a udf validator
+    "childObject": { udf: function( value, target, errorMetadata ) {
+            // validate the child object
+            var validationResult = validationManager.validate( childObject );
+
+            // if the child object has errors, populate the error metadata and return false
+            if ( validationResult.hasErrors() ) {
+                
+                errorMetadata[ "customMessage" ] = "Child object failed validation! Reasons: ";
+                
+                // append each error message to our custom error message
+                validationResult.getAllErrors().each( function( error, index ) {
+                    errorMetadata[ "customMessage" ] &= "#index#. #error# ";
+                } );
+
+                return false;
+            }
+            
+            return true; 
+        },
+        // the message replacement system will look for a matching metadata key and replace it with the message from the UDF.
+        udfMessage: "{customMessage}" 
+    };
+}
+```
+
+The above code will validate a nested `ChildObject` property using the [UDF validator](../valid-constraints/README.md#udf).


### PR DESCRIPTION
This documentation relates to the following PR on cbvalidation:
https://github.com/coldbox-modules/cbvalidation/pull/48

The new feature adds an errorMetadata struct to UDF and Method validators. This is my first time making detailed changes to an Ortus book so please feel free to revise as needed to ensure people get a solid understanding of the new feature. 